### PR TITLE
Support JSON Health check format and describe usage with New Relics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17081,6 +17081,11 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
     },
+    "xml-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
+      "integrity": "sha1-OQTBQ/qOs6ADDsZG0pAqLxtwbEQ="
+    },
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
-    "snyk": "^1.199.2"
+    "snyk": "^1.199.2",
+    "xml-escape": "^1.1.0"
   },
   "devDependencies": {
     "@adobe/openwhisk-action-builder": "^1.2.2",

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,7 @@ function wrap(func, checks) {
       && params.__ow_path === HEALTHCHECK_PATH) {
       return report(checks, 10000, {
         body: j => j,
-        mime: 'application/json'
+        mime: 'application/json',
       });
     }
     return func(params);
@@ -158,5 +158,5 @@ function main(paramsorfunction, checks = {}) {
 }
 
 module.exports = {
-  main, wrap, report, PINGDOM_XML_PATH, xml, HEALTHCHECK_PATH
+  main, wrap, report, PINGDOM_XML_PATH, xml, HEALTHCHECK_PATH,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@
 
 /* eslint-disable no-underscore-dangle */
 const request = require('request-promise-native');
+const escape = require('xml-escape');
 const fs = require('fs');
 
 const PINGDOM_XML_PATH = '/_status_check/pingdom.xml';
@@ -23,6 +24,8 @@ function xml(o, name) {
   let value = o;
   if (typeof o === 'object') {
     value = Object.keys(o).map(k => xml(o[k], k)).join('\n');
+  } else if (typeof o === 'string') {
+    value = escape(o);
   }
   return `<${name}>${value}</${name}>`;
 }
@@ -111,7 +114,7 @@ async function report(checks = {}, timeout = 10000, decorator = { body: xml, mim
         error: {
           url: e.options.uri,
           statuscode: statusCode,
-          body: `<![CDATA[${body}]]>`,
+          body,
         },
         process: {
           activation: process.env.__OW_ACTIVATION_ID,

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ const request = require('request-promise-native');
 const fs = require('fs');
 
 const PINGDOM_XML_PATH = '/_status_check/pingdom.xml';
+const HEALTHCHECK_PATH = '/_status_check/healthcheck.json';
 
 let _version;
 
@@ -127,6 +128,14 @@ function wrap(func, checks) {
       && params.__ow_path === PINGDOM_XML_PATH) {
       return report(checks);
     }
+    // New Relic status check?
+    if (params
+      && params.__ow_path === HEALTHCHECK_PATH) {
+      return report(checks, 10000, {
+        body: j => j,
+        mime: 'application/json'
+      });
+    }
     return func(params);
   };
 }
@@ -149,5 +158,5 @@ function main(paramsorfunction, checks = {}) {
 }
 
 module.exports = {
-  main, wrap, report, PINGDOM_XML_PATH, xml,
+  main, wrap, report, PINGDOM_XML_PATH, xml, HEALTHCHECK_PATH
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -193,7 +193,7 @@ describe('Index Tests', () => {
     assert.ok(result.body.match(/<version>\d+\./));
 
     // error can be ESOCKETTIMEDOUT or ETIMEDOUT
-    assert.ok(result.body.match(/<body><!\[CDATA\[Error: E(SOCKET)?TIMEDOUT]]><\/body>/));
+    assert.ok(result.body.match(/<body>Error: E(SOCKET)?TIMEDOUT<\/body>/));
     assert.equal(result.statusCode, 500);
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,7 +21,9 @@ const NodeHttpAdapter = require('@pollyjs/adapter-node-http');
 const { setupMocha: setupPolly } = require('@pollyjs/core');
 const FSPersister = require('@pollyjs/persister-fs');
 const index = require('../src/index.js').main;
-const { wrap, report, PINGDOM_XML_PATH } = require('../src/index.js');
+const {
+  wrap, report, PINGDOM_XML_PATH, xml,
+} = require('../src/index.js');
 
 describe('Index Tests', () => {
   setupPolly({
@@ -186,5 +188,21 @@ describe('Index Tests', () => {
       }
       assert.equal(e.message, 'Invalid Arguments: expected function or object');
     }
+  });
+});
+
+describe('Test mini-XML generator', () => {
+  it('Generates XML from String', () => {
+    assert.equal(xml('Hello World', 'foo'), '<foo>Hello World</foo>');
+  });
+
+  it('Generates XML from Number', () => {
+    assert.equal(xml(12, 'foo'), '<foo>12</foo>');
+  });
+
+  it('Generates XML from Object', () => {
+    assert.equal(xml({ hey: 'ho', bar: 'baz', zip: { zap: 'zup' } }, 'foo'), `<foo><hey>ho</hey>
+<bar>baz</bar>
+<zip><zap>zup</zap></zip></foo>`);
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,7 +22,7 @@ const { setupMocha: setupPolly } = require('@pollyjs/core');
 const FSPersister = require('@pollyjs/persister-fs');
 const index = require('../src/index.js').main;
 const {
-  wrap, report, PINGDOM_XML_PATH, xml, HEALTHCHECK_PATH
+  wrap, report, PINGDOM_XML_PATH, xml, HEALTHCHECK_PATH,
 } = require('../src/index.js');
 
 describe('Index Tests', () => {


### PR DESCRIPTION
As pointed out in #29, the health check can be consumed by other tools as well. This PR adds support for a JSON-based health check and describes how to use it with New Relics.