### PR TITLE
style(package): rename to helix-status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Helix Pingdom Status
+# Helix Status
 
 > Report status for OpenWhisk Microservices for Pingdom (and others) Uptime (HTTP) checks
 
 ## Status
-[![codecov](https://img.shields.io/codecov/c/github/adobe/helix-pingdom-status.svg)](https://codecov.io/gh/adobe/helix-pingdom-status)
-[![CircleCI](https://img.shields.io/circleci/project/github/adobe/helix-pingdom-status.svg)](https://circleci.com/gh/adobe/helix-pingdom-status)
-[![GitHub license](https://img.shields.io/github/license/adobe/helix-pingdom-status.svg)](https://github.com/adobe/helix-pingdom-status/blob/master/LICENSE.txt)
-[![GitHub issues](https://img.shields.io/github/issues/adobe/helix-pingdom-status.svg)](https://github.com/adobe/helix-pingdom-status/issues)
-[![LGTM Code Quality Grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/adobe/helix-pingdom-status.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/adobe/helix-pingdom-status)
-[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![Greenkeeper badge](https://badges.greenkeeper.io/adobe/helix-pingdom-status.svg)](https://greenkeeper.io/)
+[![codecov](https://img.shields.io/codecov/c/github/adobe/helix-status.svg)](https://codecov.io/gh/adobe/helix-status)
+[![CircleCI](https://img.shields.io/circleci/project/github/adobe/helix-status.svg)](https://circleci.com/gh/adobe/helix-status)
+[![GitHub license](https://img.shields.io/github/license/adobe/helix-status.svg)](https://github.com/adobe/helix-status/blob/master/LICENSE.txt)
+[![GitHub issues](https://img.shields.io/github/issues/adobe/helix-status.svg)](https://github.com/adobe/helix-status/issues)
+[![LGTM Code Quality Grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/adobe/helix-status.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/adobe/helix-status)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![Greenkeeper badge](https://badges.greenkeeper.io/adobe/helix-status.svg)](https://greenkeeper.io/)
 
 ## Problem
 
@@ -24,23 +24,23 @@ Finally, you know that there are [Uptime (HTTP) Checks](https://help.pingdom.com
 
 ## Solution
 
-`helix-pingdom-status` is:
+`helix-status` is:
 
 1. a micro service (running as an OpenWhisk HTTP action) that responds to Pingdom Uptime (HTTP) Checks (and similar)
 2. a library that allows you to wrap your own actions to get a standardized monitoring response
 
-# Helix Pingdom Status (as a Service)
+# Helix Status (as a Service)
 
 ## Usage
 
-The service is installed and available for Adobe I/O Runtime at `https://adobeioruntime.net/api/v1/web/helix/helix-services/pingdom-status@latest`.
+The service is installed and available for Adobe I/O Runtime at `https://adobeioruntime.net/api/v1/web/helix/helix-services/status@latest`.
 
 ```bash
-curl https://adobeioruntime.net/api/v1/web/helix/helix-services/pingdom-status@latest/_status_check/pingdom.xml
-curl https://adobeioruntime.net/api/v1/web/helix/helix-services/pingdom-status@latest/_status_check/healthcheck.json
+curl https://adobeioruntime.net/api/v1/web/helix/helix-services/status@latest/_status_check/pingdom.xml
+curl https://adobeioruntime.net/api/v1/web/helix/helix-services/status@latest/_status_check/healthcheck.json
 ```
 
-If you want to monitor the availability of Adobe I/O Runtime, just add a new [Uptime (HTTP) Check](https://help.pingdom.com/hc/en-us/articles/203679631-How-to-set-up-an-uptime-HTTP-check) in Pingdom, using the `https://` protocol, and `adobeioruntime.net/api/v1/web/helix/helix-services/pingdom-status@latest/_status_check/pingdom.xml` as the URL.
+If you want to monitor the availability of Adobe I/O Runtime, just add a new [Uptime (HTTP) Check](https://help.pingdom.com/hc/en-us/articles/203679631-How-to-set-up-an-uptime-HTTP-check) in Pingdom, using the `https://` protocol, and `adobeioruntime.net/api/v1/web/helix/helix-services/status@latest/_status_check/pingdom.xml` as the URL.
 
 ## Deployment in your own Namespace
 
@@ -57,7 +57,7 @@ $ npm run deploy
 ## Installation
 
 ```bash
-$ npm install -S @adobe/helix-pingdom-status
+$ npm install -S @adobe/helix-status
 ```
 
 ## Usage
@@ -65,7 +65,7 @@ $ npm install -S @adobe/helix-pingdom-status
 In the entry point of your action, add
 
 ```javascript
-const { wrap } = require('@adobe/helix-pingdom-status');
+const { wrap } = require('@adobe/helix-status');
 ```
 
 to the top of your file and override the `module.exports.main` with:
@@ -84,7 +84,7 @@ All `GET /_status_check/pingdom.xml` requests to your service will now respond w
 </pingdom_http_custom_check
 ```
 
-> **Note**: While the XML response format is similar to the one described in [Pingdom Custom HTTP Check](https://help.pingdom.com/hc/en-us/articles/115000431709-HTTP-Custom-Check) the `/_status_check/pingdom.xml` request is intented to be used for standard Pingdom UPTIME Checks only. It's _not_ suitable for Custom HTTP Checks which  expect an HTTP Status 200 XML response whereas UPTIME Checks determine the status of a service (UP/DOWN) based on the HTTP Status code of the response. For more information see [#21](https://github.com/adobe/helix-pingdom-status/issues/21) and [here](https://help.pingdom.com/hc/en-us/articles/203749792-What-is-a-check-).
+> **Note**: While the XML response format is similar to the one described in [Pingdom Custom HTTP Check](https://help.pingdom.com/hc/en-us/articles/115000431709-HTTP-Custom-Check) the `/_status_check/pingdom.xml` request is intented to be used for standard Pingdom UPTIME Checks only. It's _not_ suitable for Custom HTTP Checks which  expect an HTTP Status 200 XML response whereas UPTIME Checks determine the status of a service (UP/DOWN) based on the HTTP Status code of the response. For more information see [#21](https://github.com/adobe/helix-status/issues/21) and [here](https://help.pingdom.com/hc/en-us/articles/203749792-What-is-a-check-).
 
 You can also specify a list of checks to run by passing second argument to `wrap`:
 
@@ -106,13 +106,13 @@ It is a good idea to use URLs that are representative of the API endpoints your 
 
 # Usage with New Relics Synthetics
 
-[New Relic Synthetics](https://docs.newrelic.com/docs/synthetics) is a service that is similar to Pingdom, but more capable. It can be used with `helix-pingdom-status` by creating an API Check script like this:
+[New Relic Synthetics](https://docs.newrelic.com/docs/synthetics) is a service that is similar to Pingdom, but more capable. It can be used with `helix-status` by creating an API Check script like this:
 
 ```javascript
 const assert = require('assert');
 
 // replace the URL with your check URL
-$http.get('https://adobeioruntime.net/api/v1/web/helix/helix-services/pingdom-status@v3/_status_check/heathcheck.json',
+$http.get('https://adobeioruntime.net/api/v1/web/helix/helix-services/status@v3/_status_check/heathcheck.json',
   // Callback
   function (err, response, body) {
     assert.equal(response.statusCode, 200, 'Expected a 200 OK response');
@@ -136,4 +136,4 @@ $http.get('https://adobeioruntime.net/api/v1/web/helix/helix-services/pingdom-st
 
 Deploying Helix Pingdom Status requires the `wsk` command line client, authenticated to a namespace of your choice. For Project Helix, we use the `helix` namespace.
 
-All commits to master that pass the testing will be deployed automatically. All commits to branches that will pass the testing will get commited as `/helix-services/pingdom-status@ci<num>` and tagged with the CI build number.
+All commits to master that pass the testing will be deployed automatically. All commits to branches that will pass the testing will get commited as `/helix-services/status@ci<num>` and tagged with the CI build number.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@adobe/helix-pingdom-status",
+  "name": "@adobe/helix-status",
   "version": "3.1.0",
-  "description": "Report status for OpenWhisk Microservices for Pingdom Uptime (HTTP) checks",
+  "description": "Report status for OpenWhisk Microservices for Uptime checks with Pingdom or New Relic",
   "main": "src/index.js",
   "scripts": {
     "test": "nyc --reporter=text --reporter=lcov --check-coverage --branches 100 --statements 100 --lines 100 mocha",
@@ -18,14 +18,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/adobe/helix-pingdom-status"
+    "url": "https://github.com/adobe/helix-status"
   },
   "author": "",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/adobe/helix-pingdom-status/issues"
+    "url": "https://github.com/adobe/helix-status/issues"
   },
-  "homepage": "https://github.com/adobe/helix-pingdom-status#readme",
+  "homepage": "https://github.com/adobe/helix-status#readme",
   "dependencies": {
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
@@ -74,7 +74,7 @@
     }
   },
   "wsk": {
-    "name": "helix-services/pingdom-status@3.1.0",
+    "name": "helix-services/status@3.1.0",
     "static": []
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Adjusts the package name to `helix-status`, as the library and service is no longer exclusive to Pingdom. The service will be available under a new name and the old package will be marked as deprecated on NPM with instructions to update to the new status library.

fixes #29 – update your `package.json` references from `@adobe/helix-pingdom-status` to `@adobe/helix-status`

